### PR TITLE
Force chunk preloading on enable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build
 gradle
 
 # other
+.DS_Store
 eclipse
 run
 gradlew

--- a/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/config/MinemaConfig.java
@@ -60,6 +60,7 @@ public class MinemaConfig {
 	public final ConfigDouble engineSpeed = new ConfigDouble(1.0, 0.01, 100.0);
 	public final ConfigBoolean syncEngine = new ConfigBoolean(true);
 	public final ConfigBoolean preloadChunks = new ConfigBoolean(true);
+	public final ConfigBoolean forcePreloadChunks = new ConfigBoolean(false);
 
 	public MinemaConfig(Configuration cfg) {
 		this.configForge = cfg;
@@ -92,6 +93,7 @@ public class MinemaConfig {
 		engineSpeed.link(cfg, ENGINE_CATEGORY, "engineSpeed", LANG_KEY);
 		syncEngine.link(cfg, ENGINE_CATEGORY, "syncEngine", LANG_KEY);
 		preloadChunks.link(cfg, ENGINE_CATEGORY, "preloadChunks", LANG_KEY);
+		forcePreloadChunks.link(cfg, ENGINE_CATEGORY, "forcePreloadChunks", LANG_KEY);
 	}
 
 	public Configuration getConfigForge() {

--- a/src/main/java/info/ata4/minecraft/minema/client/modules/ChunkPreloader.java
+++ b/src/main/java/info/ata4/minecraft/minema/client/modules/ChunkPreloader.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import info.ata4.minecraft.minema.client.config.MinemaConfig;
 import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.client.renderer.ViewFrustum;
 import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+import net.minecraft.client.renderer.chunk.CompiledChunk;
 import net.minecraft.client.renderer.chunk.RenderChunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -18,6 +20,7 @@ public class ChunkPreloader extends CaptureModule {
 	private Field renderInfosField;
 	private Field renderDispatcherField;
 	private Field renderChunkField;
+	private Field renderViewFrustum;
 
 	public ChunkPreloader(MinemaConfig cfg) {
 		super(cfg);
@@ -57,6 +60,8 @@ public class ChunkPreloader extends CaptureModule {
 		renderInfosField.setAccessible(true);
 		renderDispatcherField = RenderGlobal.class.getDeclaredField("field_174995_M");
 		renderDispatcherField.setAccessible(true);
+		renderViewFrustum = RenderGlobal.class.getDeclaredField("field_175008_n");
+		renderViewFrustum.setAccessible(true);
 
 		for (Class<?> innerClass : RenderGlobal.class.getDeclaredClasses()) {
 			if (innerClass.getName().endsWith("ContainerLocalRenderInformation")) {
@@ -68,6 +73,22 @@ public class ChunkPreloader extends CaptureModule {
 
 		if (renderInfosField == null || renderDispatcherField == null || renderChunkField == null)
 			return;
+
+		if (cfg.forcePreloadChunks.get() && renderViewFrustum != null) {
+			try {
+				ChunkRenderDispatcher chunks = (ChunkRenderDispatcher) renderDispatcherField.get(MC.renderGlobal);
+				ViewFrustum frustum = (ViewFrustum) renderViewFrustum.get(MC.renderGlobal);
+
+				for (RenderChunk chunk : frustum.renderChunks) {
+					if (chunk.getCompiledChunk() == CompiledChunk.DUMMY) {
+						chunks.updateChunkNow(chunk);
+					}
+				}
+			}
+			catch (Exception e) {
+				handleWarning(e, "Could not preload all chunks in render distance on enable, disable the config option and report the error!");
+			}
+		}
 
 		MinecraftForge.EVENT_BUS.register(this);
 	}

--- a/src/main/resources/assets/minema/lang/en_US.lang
+++ b/src/main/resources/assets/minema/lang/en_US.lang
@@ -62,3 +62,6 @@ minema.config.syncEngine.tooltip=If enabled, the local server and client runs sy
 
 minema.config.preloadChunks=Preload Chunks
 minema.config.preloadChunks.tooltip=If enabled, Minema will heavily accelerate the chunk loading rate during recording. THIS IS ONLY TRULY EFFECTIVE ON LOCAL WORLDS!
+
+minema.config.forcePreloadChunks=Force preload chunks
+minema.config.forcePreloadChunks.tooltip=If Preload Chunks is enabled and this is also enabled, all chunks in render distance will be preloaded. THIS IS ONLY TRULY EFFECTIVE ON LOCAL WORLDS!


### PR DESCRIPTION
This pull request will allow users to configure `Preload chunks` feature to allow loading every chunk in the render distance on recording start. I called it `Force preload chunks`, but if you want to, you can rename both of those config options to be more semantic and clear.

P.S.: how do you test these SRG named reflection in Eclipse? I had to look up the names in order to make it work in Eclipse first, and then change it back to SRG.